### PR TITLE
Allow starting a SSM session manually from a SSM websocket URL and token

### DIFF
--- a/datachannel/data_channel.go
+++ b/datachannel/data_channel.go
@@ -465,13 +465,17 @@ func (c *SsmDataChannel) startSession(cfg aws.Config, in *ssm.StartSessionInput)
 	if err != nil {
 		return err
 	}
+	return c.StartSessionFromDataChannelURL(*out.StreamUrl, *out.TokenValue)
+}
 
-	c.ws, _, err = websocket.DefaultDialer.Dial(*out.StreamUrl, http.Header{}) //nolint:bodyclose
+func (c *SsmDataChannel) StartSessionFromDataChannelURL(url string, token string) error {
+	ws, _, err := websocket.DefaultDialer.Dial(url, http.Header{}) //nolint:bodyclose
 	if err != nil {
 		return err
 	}
+	c.ws = ws
 
-	if err = c.openDataChannel(*out.TokenValue); err != nil {
+	if err = c.openDataChannel(token); err != nil {
 		_ = c.Close()
 		return err
 	}


### PR DESCRIPTION
Hello!

Thanks for this great project. This PR adds a method to allow starting a session from a raw websocket URL. This turned out to be useful for me in several cases (especially when using undocumented APIs) so it would be great to make it available!