### PR TITLE
Fix number of bugs in datachannel.WriteTo

### DIFF
--- a/datachannel/data_channel.go
+++ b/datachannel/data_channel.go
@@ -132,9 +132,14 @@ func (c *SsmDataChannel) WriteTo(w io.Writer) (n int64, err error) {
 
 		if nr > 0 {
 			payload, err = c.HandleMsg(buf[:nr])
+			var isEOF bool
 			if err != nil {
-				log.Printf("WriteTo HandleMsg error: %v", err)
-				return int64(nw), err
+				if errors.Is(err, io.EOF) {
+					isEOF = true
+				} else {
+					log.Printf("WriteTo HandleMsg error: %v", err)
+					return n, err
+				}
 			}
 
 			if len(payload) > 0 {
@@ -144,6 +149,10 @@ func (c *SsmDataChannel) WriteTo(w io.Writer) (n int64, err error) {
 					log.Printf("WriteTo write error: %v", err)
 					return n, err
 				}
+			}
+			
+			if isEOF {
+				return n, nil
 			}
 		}
 	}


### PR DESCRIPTION
1. WriteTo should not return EOF (see https://github.com/golang/go/issues/44411).
2. In case of EOF, WriteTo should write the final payload before returning
3. In case of non EOF error, WriteTo should return n, not nw.