### PR TITLE
Add SSM KMS info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ an AWS SDK client.ConfigProvider type (which can be satisfied with a session.Ses
 target to connect with.  For now, this client has only been tested on macOS and Linux, connecting to a Linux target.
 See the [example](examples/ssm-shell) for a simple implementation.
 
+Note: If you have enabled KMS encryption for Sessions, then use `ssmclient.ShellPluginSession()`.
+
 ## SSH
 SSH over SSM integration can be leveraged via the `ssmclient.SshSession()` function.  Since the SSM SSH integration is
 a specialized form of port forwarding, the function takes the same arguments as `ssmclient.PortForwardingSession()`.


### PR DESCRIPTION
based on conversation in this issue https://github.com/mmmorris1975/ssm-session-client/issues/10 I tried out new way mentioned by @mmmorris1975 and it worked in my project: https://github.com/surajincloud/kubectl-eks/pull/7 🎉 

This PR will add simple note in the README to guide users who are using KMS encryption for SSM Sessions.