### PR TITLE
Fixed error that caused the session to not return when finished

### DIFF
--- a/ssmclient/shell.go
+++ b/ssmclient/shell.go
@@ -43,8 +43,8 @@ func ShellSession(cfg aws.Config, target string, initCmd ...io.Reader) error {
 		if !errors.Is(err, io.EOF) {
 			errCh <- err
 		}
-		close(errCh)
 	}
+	close(errCh)
 
 	return <-errCh
 }

--- a/ssmclient/ssh.go
+++ b/ssmclient/ssh.go
@@ -62,8 +62,8 @@ func SSHSession(cfg aws.Config, opts *PortForwardingInput) error {
 			errCh <- err
 		}
 		log.Print("EOF received from websocket -> stdout copy")
-		close(errCh)
 	}
+	close(errCh)
 
 	return <-errCh
 }


### PR DESCRIPTION
When finished the ssm session the connection don't return to the caller. 

How to replicate this error:

1. Using the ssm-shell example connect to any target
2. Enter the command `exit`
