### PR TITLE
Adds context-based cancellation to port-forwarding sessions

### DIFF
--- a/ssmclient/port_forwarding.go
+++ b/ssmclient/port_forwarding.go
@@ -107,9 +107,13 @@ outer:
 		var conn net.Conn
 		conn, err = lsnr.Accept()
 		if err != nil {
-			// not fatal, just wait for next (maybe unless lsnr is dead?)
-			log.Print(err)
-			continue
+			select {
+			case <-ctx.Done():
+				break outer // Expected error due to shutdown
+			default:
+				log.Print(err)
+				continue
+			}
 		}
 
 		go func() {

--- a/ssmclient/ssh.go
+++ b/ssmclient/ssh.go
@@ -1,14 +1,16 @@
 package ssmclient
 
 import (
+	"context"
 	"errors"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/ssm"
-	"github.com/mmmorris1975/ssm-session-client/datachannel"
 	"io"
 	"log"
 	"os"
 	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/mmmorris1975/ssm-session-client/datachannel"
 )
 
 // SSHSession starts a specialized port forwarding session to allow SSH connectivity to the target instance over
@@ -42,7 +44,7 @@ func SSHSession(cfg aws.Config, opts *PortForwardingInput) error {
 	installSignalHandler(c)
 
 	log.Print("waiting for handshake")
-	if err := c.WaitForHandshakeComplete(); err != nil {
+	if err := c.WaitForHandshakeComplete(context.Background()); err != nil {
 		return err
 	}
 	log.Print("handshake complete")


### PR DESCRIPTION
Thank you for this package! It's fantastic to be able to manage ssm sessions completely in go instead of having to deal with aws cli subprocesses.

I'm writing an application that can create multiple port forwarding sessions at once and requires the ability to cleanly exit them using a context (`os.Exit` is a dealbreaker). So I implemented a `PortForwardingSessionWithContext` that handles this capability. It functions basically the same as the existing func, just does not register a signal handler. 

I didn't want to mess with the public API too much, although I did add a context to `WaitForHandshakeComplete`. But `PortForwardingSession()` should have the same behavior as it did prior to this change.

There is also a bit of cruft handling the case where the `lsnr` has not accepted a connection yet, since the `Accept()` function does not accept a context.
