### PR TITLE
Fix data corruption in port forwarding

### DIFF
--- a/datachannel/agent_message.go
+++ b/datachannel/agent_message.go
@@ -96,7 +96,8 @@ func (m *AgentMessage) UnmarshalBinary(data []byte) error {
 
 	payloadLenEnd := m.headerLength + 4
 	m.payloadLength = binary.BigEndian.Uint32(data[m.headerLength:payloadLenEnd])
-	m.Payload = data[payloadLenEnd : payloadLenEnd+m.payloadLength]
+	// Copy payload to avoid data corruption when the underlying buffer is reused
+	m.Payload = append([]byte(nil), data[payloadLenEnd:payloadLenEnd+m.payloadLength]...)
 
 	return m.ValidateMessage()
 }

--- a/datachannel/data_channel.go
+++ b/datachannel/data_channel.go
@@ -254,10 +254,14 @@ func (c *SsmDataChannel) HandleMsg(data []byte) ([]byte, error) {
 		if c.outMsgBuf != nil {
 			c.outMsgBuf.Remove(m.SequenceNumber)
 		}
+		// Don't send ACK for ACK messages
+		return nil, nil
 	case PausePublication:
 		c.pausePub = true
+		return nil, nil
 	case StartPublication:
 		c.pausePub = false
+		return nil, nil
 	case OutputStreamData:
 		switch m.PayloadType {
 		case Output:

--- a/ssmclient/port_forwarding.go
+++ b/ssmclient/port_forwarding.go
@@ -229,7 +229,7 @@ func messageChannel(c datachannel.DataChannel, errCh chan error) chan []byte {
 			}
 
 			if len(payload) > 0 {
-				inCh <- append([]byte(nil), payload...)
+				inCh <- payload
 			}
 		}
 	}()

--- a/ssmclient/port_forwarding.go
+++ b/ssmclient/port_forwarding.go
@@ -229,7 +229,7 @@ func messageChannel(c datachannel.DataChannel, errCh chan error) chan []byte {
 			}
 
 			if len(payload) > 0 {
-				inCh <- payload
+				inCh <- append([]byte(nil), payload...)
 			}
 		}
 	}()


### PR DESCRIPTION
Port forwarding breaks with SSH errors "Bad packet length" or "cipher: message authentication failed" under load. The payload slice sent through the channel points into a buffer that gets overwritten by the next read. Fixed by copying the payload before sending.