### PR TITLE
Fix PortForwardingSession ignoring PortForwardingInput.Host field

### DIFF
--- a/ssmclient/port_forwarding.go
+++ b/ssmclient/port_forwarding.go
@@ -171,6 +171,18 @@ outer:
 // PortPluginSession delegates the execution of the SSM port forwarding to the AWS-managed session manager plugin code,
 // bypassing this libraries internal websocket code and connection management.
 func PortPluginSession(cfg aws.Config, opts *PortForwardingInput) error {
+	return PluginSession(cfg, portForwardingSessionInput(opts))
+}
+
+func openDataChannel(cfg aws.Config, opts *PortForwardingInput) (*datachannel.SsmDataChannel, error) {
+	c := new(datachannel.SsmDataChannel)
+	if err := c.Open(cfg, portForwardingSessionInput(opts)); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func portForwardingSessionInput(opts *PortForwardingInput) *ssm.StartSessionInput {
 	documentName := "AWS-StartPortForwardingSession"
 	parameters := map[string][]string{
 		"localPortNumber": {strconv.Itoa(opts.LocalPort)},
@@ -178,34 +190,15 @@ func PortPluginSession(cfg aws.Config, opts *PortForwardingInput) error {
 	}
 
 	if opts.Host != "" {
-		parameters["host"] = []string{opts.Host}
 		documentName = "AWS-StartPortForwardingSessionToRemoteHost"
+		parameters["host"] = []string{opts.Host}
 	}
 
-	in := &ssm.StartSessionInput{
+	return &ssm.StartSessionInput{
 		DocumentName: aws.String(documentName),
 		Target:       aws.String(opts.Target),
 		Parameters:   parameters,
 	}
-
-	return PluginSession(cfg, in)
-}
-
-func openDataChannel(cfg aws.Config, opts *PortForwardingInput) (*datachannel.SsmDataChannel, error) {
-	in := &ssm.StartSessionInput{
-		DocumentName: aws.String("AWS-StartPortForwardingSession"),
-		Target:       aws.String(opts.Target),
-		Parameters: map[string][]string{
-			"localPortNumber": {strconv.Itoa(opts.LocalPort)},
-			"portNumber":      {strconv.Itoa(opts.RemotePort)},
-		},
-	}
-
-	c := new(datachannel.SsmDataChannel)
-	if err := c.Open(cfg, in); err != nil {
-		return nil, err
-	}
-	return c, nil
 }
 
 // read messages from websocket and write payload to the returned channel.


### PR DESCRIPTION
## Summary

- `openDataChannel` was hardcoded to `AWS-StartPortForwardingSession` and never passed the `host` parameter, causing remote host port forwarding to silently connect to the target instance's own port instead of the intended remote host
- Extracts a `portForwardingSessionInput()` helper shared by both `openDataChannel` and `PortPluginSession`, which correctly selects `AWS-StartPortForwardingSessionToRemoteHost` and includes the `host` parameter when `opts.Host` is set
- Reduces code duplication — the document/parameter selection logic now lives in one place

Fixes #26

## Test plan

- [ ] `PortForwardingSession` / `PortForwardingSessionWithContext` with `Host` set connects to the remote host, not the target instance
- [ ] `PortForwardingSession` / `PortForwardingSessionWithContext` with no `Host` set continues to work as before (uses `AWS-StartPortForwardingSession`)
- [ ] `PortPluginSession` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)